### PR TITLE
Fixes #32: respond to deprecation warnings

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -20,7 +20,7 @@ BmoreonrailsOrg::Application.configure do
   # config.action_dispatch.rack_cache = true
 
   # Disable Rails's static asset server (Apache or nginx will already do this).
-  config.serve_static_assets = true
+  config.serve_static_files = true
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -13,7 +13,7 @@ BmoreonrailsOrg::Application.configure do
   config.eager_load = false
 
   # Configure static asset server for tests with Cache-Control for performance.
-  config.serve_static_assets  = true
+  config.serve_static_files  = true
   config.static_cache_control = "public, max-age=3600"
 
   # Show full error reports and disable caching.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -33,4 +33,7 @@ BmoreonrailsOrg::Application.configure do
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
+
+  # run tests in random order
+  config.active_support.test_order = :random
 end


### PR DESCRIPTION
fixes #32 

- Update config to use `serve_static_files`.
- Update config to run tests in random order.
- upgrade db/schema  to use `force: cascade` (default in 4.2)
  - https://stackoverflow.com/questions/27697119/what-is-cascade-in-rails-schema-rb-and-where-did-it-come-from
