### PR TITLE
Link to tito instead of school page

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -21,7 +21,7 @@
               %li#join
                 %a{href: 'http://www.meetup.com/bmore-on-rails', title: 'Our Meetup Page'} Join Us on Meetup!
               %li#join
-                %a{href: pages_school_path, title: 'school'} School
+                %a{href: 'https://ti.to/bmore-on-rails-workshop-for-women/2017', title: 'school'} School
               %li#join
                 %a{href: root_path, title: 'home'} Home
 


### PR DESCRIPTION
This gets rid of the school page and links out directly to ti.to so that I don't have to manage two sites. 