### PR TITLE
Update meetup URL, add documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,19 @@ This command requires that you have ImageMagick installed on your machine. If yo
 To resize one image:
 
     convert -define jpeg:size=200x200 original_avatar.jpg -thumbnail 200x200^ -gravity center -extent 200x200  your_avatar.jpg
+
+### Meetup integration
+
+#### API key management
+
+We use an ["API key signed URL"](https://www.meetup.com/meetup_api/auth/#keysign) to pull meetups from our meetup page onto the site. If this key is removed, a brave soul will be tasked with forming a new `UPCOMING_EVENTS_URL` in the Meetup model. This is accomplished by:
+
+1) ["Getting or generating your API key"](https://secure.meetup.com/meetup_api/key/) from meetup.
+2) Making the desired request with your API key: https://api.meetup.com/2/events?key=(YOUR_KEY_HERE)&group_id=347566&sign=true&status=upcoming&order=time&limited_events=False&desc=false&offset=0&format=json&page=20&fields=&time=%2C5w
+3) Update the `UPCOMING_EVENTS_URL` in the Meetup model using the `signed_url` returned in the meta response
+
+You shouldn't update the `UPCOMING_EVENTS_URL` value with the URL you use in step 2 because that contains your API key, which anyone can use to make authorized requests against the meetup API, as well as to pull information from YOUR meetup account.
+
+#### Updating meetups in development
+
+In production meetups are updated with a scheduled job, in order to update the meetups locally you have to use the rake task `rake update_meetups`.

--- a/app/models/meetup.rb
+++ b/app/models/meetup.rb
@@ -1,5 +1,5 @@
 class Meetup < ActiveRecord::Base
-  UPCOMING_EVENTS_URL = 'http://api.meetup.com/2/events?group_id=347566&status=upcoming&order=time&limited_events=False&desc=false&offset=0&format=json&page=20&fields=&time=%2C5w&sig_id=9347737&sig=f6274cfd7bf5c34df7ec77400585d13b00a0666e'
+  UPCOMING_EVENTS_URL = 'https://api.meetup.com/2/events?offset=0&format=json&limited_events=False&group_id=347566&page=20&time=%2C5w&fields=&order=time&status=upcoming&desc=false&sig_id=11618449&sig=c6ee2ab0360a1f1cee5024d5e34dd8b26d5df9ab'
 
   scope :upcoming, -> { where('time > now()').order('time ASC') }
 

--- a/app/models/meetup.rb
+++ b/app/models/meetup.rb
@@ -1,5 +1,5 @@
 class Meetup < ActiveRecord::Base
-  UPCOMING_EVENTS_URL = 'https://api.meetup.com/2/events?offset=0&format=json&limited_events=False&group_id=347566&page=20&time=%2C5w&fields=&order=time&status=upcoming&desc=false&sig_id=11618449&sig=c6ee2ab0360a1f1cee5024d5e34dd8b26d5df9ab'
+  UPCOMING_EVENTS_URL = 'https://api.meetup.com/2/events?offset=0&format=json&limited_events=False&group_id=347566&page=20&time=%2C5w&fields=&order=time&desc=false&status=upcoming&sig_id=7982375&sig=ef8c99bf8d8c69ea75228e2d3ba430ba77132508'
 
   scope :upcoming, -> { where('time > now()').order('time ASC') }
 


### PR DESCRIPTION
For some reason the prior API key signed Meetup URL stopped working, so
I used my meetup API key to generate a new signed URL.

I got a bit confused in the process, both in how to generate a new
signed URL and how to update the meetups locally, so I added
documentation to the readme.